### PR TITLE
Add seen list to avoid duplicates in queue due to async

### DIFF
--- a/scripts/run_scrapers.py
+++ b/scripts/run_scrapers.py
@@ -45,16 +45,16 @@ if __name__ == "__main__":
     )
 
     scrapers = [
-        ("Yahoo", yahoo_scraper),
-        ("Sky", sky_scraper),
-        ("CBC", cbc_scraper),
-        ("ABC", abc_scraper),
-        ("Fox", fox_scraper),
-        ("NBC", nbc_scraper),
-        ("Irish Times", irish_times_scraper),
-        ("BusinessTech", businesstech_scraper),
+        # ("Yahoo", yahoo_scraper),
+        # ("Sky", sky_scraper),
+        # ("CBC", cbc_scraper),
+        # ("ABC", abc_scraper),
+        # ("Fox", fox_scraper),
+        # ("NBC", nbc_scraper),
+        # ("Irish Times", irish_times_scraper),
+        # ("BusinessTech", businesstech_scraper),
         ("RNZ", rnz_scraper),
-        ("Herald", herald_scraper),
+        # ("Herald", herald_scraper),
     ]
 
     for name, scraper in scrapers:


### PR DESCRIPTION
Add seen set to stop URLs being added to queue multiple times.

Example:
Worker A scrapes page, finds www.example.com and adds to the queue.
Worker B scrapes page, finds www.example.com and adds to the queue.
Worker A scrapes www.example.com
Worker B scrapes www.example.com (second instance in the queue) **but** before Worker A adds www.example.com to `visited`
Result is www.example.com is scraped twice in one session, leading to redundancy.

Fix adds `seen` that tracks URLs as they are pulled from the page, not after a successful scrape. If a URL has been seen then it will not be added to the queue again. 